### PR TITLE
TPIK Pos Adjustments & Casing Scaling

### DIFF
--- a/lua/weapons/arc9_cod2019_50gs.lua
+++ b/lua/weapons/arc9_cod2019_50gs.lua
@@ -222,7 +222,7 @@ SWEP.CamQCA_Mult = 1
 SWEP.ShellModel = "models/models/weapons/shared/shell_9mm_hr.mdl"
 SWEP.ShellSounds = ARC9.PistolShellSoundsTable
 SWEP.ShellCorrectAng = Angle(0, 0, 0)
-SWEP.ShellScale = 0.12
+SWEP.ShellScale = 0.06
 SWEP.ShellPhysBox = Vector(0.5, 0.5, 2)
 
 SWEP.ShouldDropMag = false

--- a/lua/weapons/arc9_cod2019_725.lua
+++ b/lua/weapons/arc9_cod2019_725.lua
@@ -38,8 +38,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_shot_725.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-11, 6, -2.5),
     Ang = Angle(-17, 3, 180),
-    TPIKPos = Vector(-15, 5, 0),
-    TPIKAng = Angle(0, 0, 180),
+    TPIKPos = Vector(-2, 4, -2),
+    TPIKAng = Angle(-8, 0, 180),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_ak47.lua
+++ b/lua/weapons/arc9_cod2019_ak47.lua
@@ -36,8 +36,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_rif_ak47.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-5, 5, -2),
+    TPIKAng = Angle(-9, 0, 170),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_akimbo_357.lua
+++ b/lua/weapons/arc9_cod2019_akimbo_357.lua
@@ -36,8 +36,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_akimbo_357.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-5, 4, -5),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-4, 7.5, -3),
+    TPIKAng = Angle(-9, 0, 180),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_akimbo_50gs.lua
+++ b/lua/weapons/arc9_cod2019_akimbo_50gs.lua
@@ -229,7 +229,7 @@ SWEP.CamQCA_Mult = 1
 SWEP.ShellModel = "models/models/weapons/shared/shell_9mm_hr.mdl"
 SWEP.ShellSounds = ARC9.PistolShellSoundsTable
 SWEP.ShellCorrectAng = Angle(0, 0, 0)
-SWEP.ShellScale = 0.12
+SWEP.ShellScale = 0.06
 SWEP.ShellPhysBox = Vector(0.5, 0.5, 2)
 
 SWEP.ShouldDropMag = false

--- a/lua/weapons/arc9_cod2019_akimbo_50gs.lua
+++ b/lua/weapons/arc9_cod2019_akimbo_50gs.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_akimbo_50gs.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-5, 4, -5),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-4, 7.5, -3),
+    TPIKAng = Angle(-9, 0, 180),
     Scale = 1
 }
 
@@ -198,10 +198,10 @@ SWEP.CustomizeNoRotate = false
 
 -------------------------- HoldTypes
 
-SWEP.HoldType = "duel"
-SWEP.HoldTypeSprint = "duel"
-SWEP.HoldTypeHolstered = "duel"
-SWEP.HoldTypeSights = "duel"
+SWEP.HoldType = "rpg"
+SWEP.HoldTypeSprint = "rpg"
+SWEP.HoldTypeHolstered = "rpg"
+SWEP.HoldTypeSights = "rpg"
 SWEP.HoldTypeCustomize = "slam"
 SWEP.HoldTypeBlindfire = "pistol"
 

--- a/lua/weapons/arc9_cod2019_akimbo_m19.lua
+++ b/lua/weapons/arc9_cod2019_akimbo_m19.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_akimbo_m19.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-5, 4, -5),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-4, 7.5, -3),
+    TPIKAng = Angle(-9, 0, 180),
     Scale = 1
 }
 
@@ -197,10 +197,10 @@ SWEP.CustomizeNoRotate = false
 
 -------------------------- HoldTypes
 
-SWEP.HoldType = "duel"
-SWEP.HoldTypeSprint = "duel"
-SWEP.HoldTypeHolstered = "duel"
-SWEP.HoldTypeSights = "duel"
+SWEP.HoldType = "rpg"
+SWEP.HoldTypeSprint = "rpg"
+SWEP.HoldTypeHolstered = "rpg"
+SWEP.HoldTypeSights = "rpg"
 SWEP.HoldTypeCustomize = "slam"
 SWEP.HoldTypeBlindfire = "pistol"
 

--- a/lua/weapons/arc9_cod2019_akimbo_m19.lua
+++ b/lua/weapons/arc9_cod2019_akimbo_m19.lua
@@ -228,7 +228,7 @@ SWEP.CamQCA_Mult = 1
 SWEP.ShellModel = "models/models/weapons/shared/shell_9mm_hr.mdl"
 SWEP.ShellSounds = ARC9.PistolShellSoundsTable
 SWEP.ShellCorrectAng = Angle(0, 0, 0)
-SWEP.ShellScale = 0.08
+SWEP.ShellScale = 0.06
 SWEP.ShellPhysBox = Vector(0.5, 0.5, 2)
 
 SWEP.ShouldDropMag = false

--- a/lua/weapons/arc9_cod2019_akimbo_m1911.lua
+++ b/lua/weapons/arc9_cod2019_akimbo_m1911.lua
@@ -36,8 +36,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_akimbo_m1911.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-5, 4, -5),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-4, 7.5, -3),
+    TPIKAng = Angle(-9, 0, 180),
     Scale = 1
 }
 
@@ -194,10 +194,10 @@ SWEP.CustomizeNoRotate = false
 
 -------------------------- HoldTypes
 
-SWEP.HoldType = "duel"
-SWEP.HoldTypeSprint = "duel"
-SWEP.HoldTypeHolstered = "duel"
-SWEP.HoldTypeSights = "duel"
+SWEP.HoldType = "rpg"
+SWEP.HoldTypeSprint = "rpg"
+SWEP.HoldTypeHolstered = "rpg"
+SWEP.HoldTypeSights = "rpg"
 SWEP.HoldTypeCustomize = "slam"
 SWEP.HoldTypeBlindfire = "pistol"
 

--- a/lua/weapons/arc9_cod2019_akimbo_m1911.lua
+++ b/lua/weapons/arc9_cod2019_akimbo_m1911.lua
@@ -225,7 +225,7 @@ SWEP.CamQCA_Mult = 1
 SWEP.ShellModel = "models/models/weapons/shared/shell_9mm_hr.mdl"
 SWEP.ShellSounds = ARC9.PistolShellSoundsTable
 SWEP.ShellCorrectAng = Angle(0, 0, 0)
-SWEP.ShellScale = 0.08
+SWEP.ShellScale = 0.06
 SWEP.ShellPhysBox = Vector(0.5, 0.5, 2)
 
 SWEP.ShouldDropMag = false

--- a/lua/weapons/arc9_cod2019_akimbo_renetti.lua
+++ b/lua/weapons/arc9_cod2019_akimbo_renetti.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_akimbo_renetti.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-5, 4, -5),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-4, 7.5, -3),
+    TPIKAng = Angle(-9, 0, 180),
     Scale = 1
 }
 
@@ -195,10 +195,10 @@ SWEP.CustomizeNoRotate = false
 
 -------------------------- HoldTypes
 
-SWEP.HoldType = "duel"
-SWEP.HoldTypeSprint = "duel"
-SWEP.HoldTypeHolstered = "duel"
-SWEP.HoldTypeSights = "duel"
+SWEP.HoldType = "rpg"
+SWEP.HoldTypeSprint = "rpg"
+SWEP.HoldTypeHolstered = "rpg"
+SWEP.HoldTypeSights = "rpg"
 SWEP.HoldTypeCustomize = "slam"
 SWEP.HoldTypeBlindfire = "pistol"
 

--- a/lua/weapons/arc9_cod2019_akimbo_renetti.lua
+++ b/lua/weapons/arc9_cod2019_akimbo_renetti.lua
@@ -226,7 +226,7 @@ SWEP.CamQCA_Mult = 1
 SWEP.ShellModel = "models/models/weapons/shared/shell_9mm_hr.mdl"
 SWEP.ShellSounds = ARC9.PistolShellSoundsTable
 SWEP.ShellCorrectAng = Angle(0, 0, 0)
-SWEP.ShellScale = 0.08
+SWEP.ShellScale = 0.06
 SWEP.ShellPhysBox = Vector(0.5, 0.5, 2)
 
 SWEP.ShouldDropMag = false

--- a/lua/weapons/arc9_cod2019_akimbo_sykov.lua
+++ b/lua/weapons/arc9_cod2019_akimbo_sykov.lua
@@ -225,7 +225,7 @@ SWEP.CamQCA_Mult = 1
 SWEP.ShellModel = "models/models/weapons/shared/shell_9mm_hr.mdl"
 SWEP.ShellSounds = ARC9.PistolShellSoundsTable
 SWEP.ShellCorrectAng = Angle(0, 0, 0)
-SWEP.ShellScale = 0.08
+SWEP.ShellScale = 0.055
 SWEP.ShellPhysBox = Vector(0.5, 0.5, 2)
 
 SWEP.ShouldDropMag = false

--- a/lua/weapons/arc9_cod2019_akimbo_sykov.lua
+++ b/lua/weapons/arc9_cod2019_akimbo_sykov.lua
@@ -36,8 +36,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_akimbo_sykov.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-5, 4, -5),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-4, 7.5, -3),
+    TPIKAng = Angle(-9, 0, 180),
     Scale = 1
 }
 
@@ -194,10 +194,10 @@ SWEP.CustomizeNoRotate = false
 
 -------------------------- HoldTypes
 
-SWEP.HoldType = "duel"
-SWEP.HoldTypeSprint = "duel"
-SWEP.HoldTypeHolstered = "duel"
-SWEP.HoldTypeSights = "duel"
+SWEP.HoldType = "rpg"
+SWEP.HoldTypeSprint = "rpg"
+SWEP.HoldTypeHolstered = "rpg"
+SWEP.HoldTypeSights = "rpg"
 SWEP.HoldTypeCustomize = "slam"
 SWEP.HoldTypeBlindfire = "pistol"
 

--- a/lua/weapons/arc9_cod2019_akimbo_x16.lua
+++ b/lua/weapons/arc9_cod2019_akimbo_x16.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_akimbo_x16.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-5, 4, -5),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-4, 7.5, -3),
+    TPIKAng = Angle(-9, 0, 180),
     Scale = 1
 }
 
@@ -195,10 +195,10 @@ SWEP.CustomizeNoRotate = false
 
 -------------------------- HoldTypes
 
-SWEP.HoldType = "duel"
-SWEP.HoldTypeSprint = "duel"
-SWEP.HoldTypeHolstered = "duel"
-SWEP.HoldTypeSights = "duel"
+SWEP.HoldType = "rpg"
+SWEP.HoldTypeSprint = "rpg"
+SWEP.HoldTypeHolstered = "rpg"
+SWEP.HoldTypeSights = "rpg"
 SWEP.HoldTypeCustomize = "slam"
 SWEP.HoldTypeBlindfire = "pistol"
 

--- a/lua/weapons/arc9_cod2019_akimbo_x16.lua
+++ b/lua/weapons/arc9_cod2019_akimbo_x16.lua
@@ -226,7 +226,7 @@ SWEP.CamQCA_Mult = 1
 SWEP.ShellModel = "models/models/weapons/shared/shell_9mm_hr.mdl"
 SWEP.ShellSounds = ARC9.PistolShellSoundsTable
 SWEP.ShellCorrectAng = Angle(0, 0, 0)
-SWEP.ShellScale = 0.08
+SWEP.ShellScale = 0.06
 SWEP.ShellPhysBox = Vector(0.5, 0.5, 2)
 
 SWEP.ShouldDropMag = false

--- a/lua/weapons/arc9_cod2019_an94.lua
+++ b/lua/weapons/arc9_cod2019_an94.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_rif_an94.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-5, 5, -2),
+    TPIKAng = Angle(-9, 0, 170),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_asval.lua
+++ b/lua/weapons/arc9_cod2019_asval.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_rif_asval.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-5, 5, -2),
+    TPIKAng = Angle(-9, 0, 170),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_aug.lua
+++ b/lua/weapons/arc9_cod2019_aug.lua
@@ -36,8 +36,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_smg_aug.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-9.5, 5, -1.5),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_ax50.lua
+++ b/lua/weapons/arc9_cod2019_ax50.lua
@@ -38,8 +38,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_snip_ax50.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-11, 6, -2.5),
     Ang = Angle(-17, 3, 180),
-    TPIKPos = Vector(-5, 3, 0),
-    TPIKAng = Angle(-10, 3, 180),
+    TPIKPos = Vector(-5, 6, -2),
+    TPIKAng = Angle(-9, 0, 170),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_bizon.lua
+++ b/lua/weapons/arc9_cod2019_bizon.lua
@@ -36,8 +36,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_smg_bizon.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-6, 5, -1.8),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_bruenmk9.lua
+++ b/lua/weapons/arc9_cod2019_bruenmk9.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_lmg_bruenmk9.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-7, 5, -2),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_cr56amax.lua
+++ b/lua/weapons/arc9_cod2019_cr56amax.lua
@@ -36,8 +36,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_rif_cr56amax.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-7, 5, -2),
+    TPIKAng = Angle(-9, 0, 170),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_crossbow.lua
+++ b/lua/weapons/arc9_cod2019_crossbow.lua
@@ -32,8 +32,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_eq_crossbow.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-11, 6, -2.5),
     Ang = Angle(-17, 3, 180),
-    TPIKPos = Vector(-9, 5, 0),
-    TPIKAng = Angle(0, 0, 180),
+    TPIKPos = Vector(-8, 5, -2),
+    TPIKAng = Angle(-9, 0, 170),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_cx9.lua
+++ b/lua/weapons/arc9_cod2019_cx9.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_smg_evo.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-3, 3, -4),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-7, 5, -1.5),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_fal.lua
+++ b/lua/weapons/arc9_cod2019_fal.lua
@@ -38,8 +38,8 @@ SWEP.WorldModelOffset = {
     Pos = Vector(-9.5, 6.2, -5.5),
     Ang = Angle(-7, 0, 180),
     Scale = 1,
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175)
+    TPIKPos = Vector(-4, 5, -2),
+    TPIKAng = Angle(-9, 0, 175),
 }
 
 -------------------------- DAMAGE PROFILE

--- a/lua/weapons/arc9_cod2019_finn.lua
+++ b/lua/weapons/arc9_cod2019_finn.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_lmg_finn.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-7, 5, -2),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_fss.lua
+++ b/lua/weapons/arc9_cod2019_fss.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_rif_fss.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-7, 5, -1.5),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_g3a3.lua
+++ b/lua/weapons/arc9_cod2019_g3a3.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelOffset = {
     Pos = Vector(-9.5, 6.2, -5.5),
     Ang = Angle(-7, 0, 180),
     Scale = 1,
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175)
+    TPIKPos = Vector(-8.4, 5.5, -2.3),
+    TPIKAng = Angle(-9, 0, 175)
 }
 
 -------------------------- DAMAGE PROFILE

--- a/lua/weapons/arc9_cod2019_holger.lua
+++ b/lua/weapons/arc9_cod2019_holger.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_lmg_holger.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-6, 5, -2),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_iso.lua
+++ b/lua/weapons/arc9_cod2019_iso.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_smg_iso.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-8.5, 5, -1.5),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_jak12.lua
+++ b/lua/weapons/arc9_cod2019_jak12.lua
@@ -37,7 +37,7 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_shot_jak12.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-11, 6, -2.5),
     Ang = Angle(-17, 3, 180),
-    TPIKPos = Vector(-15, 5, 0),
+    TPIKPos = Vector(-3, 3, 0),
     TPIKAng = Angle(0, 0, 180),
     Scale = 1
 }

--- a/lua/weapons/arc9_cod2019_kilo141.lua
+++ b/lua/weapons/arc9_cod2019_kilo141.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_rif_kilo141.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-8, 5, -2),
+    TPIKAng = Angle(-9, 0, 170),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_m13.lua
+++ b/lua/weapons/arc9_cod2019_m13.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_rif_m13.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-5, 5, -2),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_m14.lua
+++ b/lua/weapons/arc9_cod2019_m14.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_snip_m14.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-5, 5, -1.5),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 
@@ -226,7 +226,7 @@ SWEP.CamQCA_Mult = 1
 
 SWEP.ShellModel = "models/models/weapons/shared/shell_762_hr.mdl"
 SWEP.ShellCorrectAng = Angle(0, 0, 0)
-SWEP.ShellScale = 0.1
+SWEP.ShellScale = 0.05
 SWEP.ShellPhysBox = Vector(0.5, 0.5, 2)
 
 SWEP.ShouldDropMag = false

--- a/lua/weapons/arc9_cod2019_m19.lua
+++ b/lua/weapons/arc9_cod2019_m19.lua
@@ -222,7 +222,7 @@ SWEP.CamQCA_Mult = 1
 SWEP.ShellModel = "models/models/weapons/shared/shell_9mm_hr.mdl"
 SWEP.ShellSounds = ARC9.PistolShellSoundsTable
 SWEP.ShellCorrectAng = Angle(0, 0, 0)
-SWEP.ShellScale = 0.08
+SWEP.ShellScale = 0.06
 SWEP.ShellPhysBox = Vector(0.5, 0.5, 2)
 
 SWEP.ShouldDropMag = false

--- a/lua/weapons/arc9_cod2019_m1911.lua
+++ b/lua/weapons/arc9_cod2019_m1911.lua
@@ -219,7 +219,7 @@ SWEP.CamQCA_Mult = 1
 SWEP.ShellModel = "models/models/weapons/shared/shell_9mm_hr.mdl"
 SWEP.ShellSounds = ARC9.PistolShellSoundsTable
 SWEP.ShellCorrectAng = Angle(0, 0, 0)
-SWEP.ShellScale = 0.08
+SWEP.ShellScale = 0.05
 SWEP.ShellPhysBox = Vector(0.5, 0.5, 2)
 
 SWEP.ShouldDropMag = false

--- a/lua/weapons/arc9_cod2019_m32.lua
+++ b/lua/weapons/arc9_cod2019_m32.lua
@@ -29,7 +29,7 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_eq_m32.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-11, 6, -2.5),
     Ang = Angle(-17, 3, 180),
-    TPIKPos = Vector(-15, 5, 0),
+    TPIKPos = Vector(-12, 5, 0),
     TPIKAng = Angle(0, 0, 180),
     Scale = 1
 }

--- a/lua/weapons/arc9_cod2019_m4.lua
+++ b/lua/weapons/arc9_cod2019_m4.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_rif_m4.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-7.5, 5, -2),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_m91.lua
+++ b/lua/weapons/arc9_cod2019_m91.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_lmg_m91.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-7, 5, -2),
+    TPIKAng = Angle(-9, -1, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_mp5.lua
+++ b/lua/weapons/arc9_cod2019_mp5.lua
@@ -36,8 +36,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_smg_mp5.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-10, 5, -1.5),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_mp5.lua
+++ b/lua/weapons/arc9_cod2019_mp5.lua
@@ -227,7 +227,7 @@ SWEP.CamQCA_Mult = 1
 
 SWEP.ShellModel = "models/models/weapons/shared/shell_9mm_hr.mdl"
 SWEP.ShellCorrectAng = Angle(0, 0, 0)
-SWEP.ShellScale = 0.08
+SWEP.ShellScale = 0.06
 SWEP.ShellPhysBox = Vector(0.5, 0.5, 2)
 
 SWEP.ShouldDropMag = false

--- a/lua/weapons/arc9_cod2019_mp7.lua
+++ b/lua/weapons/arc9_cod2019_mp7.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_smg_mp7.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-9, 5, -1.5),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_oden.lua
+++ b/lua/weapons/arc9_cod2019_oden.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_rif_oden.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-6.5, 5, -2),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_origin12.lua
+++ b/lua/weapons/arc9_cod2019_origin12.lua
@@ -38,7 +38,7 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_shot_origin12.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-11, 6, -2.5),
     Ang = Angle(-17, 3, 180),
-    TPIKPos = Vector(-5, 4, 0),
+    TPIKPos = Vector(-6, 4, 0),
     TPIKAng = Angle(0, 0, 180),
     Scale = 1
 }

--- a/lua/weapons/arc9_cod2019_p90.lua
+++ b/lua/weapons/arc9_cod2019_p90.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_smg_p90.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-11, 5.5, -1.5),
+    TPIKAng = Angle(-9, 0, 170),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_pila.lua
+++ b/lua/weapons/arc9_cod2019_pila.lua
@@ -32,8 +32,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_eq_pila.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-11, 6, -2.5),
     Ang = Angle(-17, 3, 180),
-    TPIKPos = Vector(-15, 5, 0),
-    TPIKAng = Angle(0, 0, 180),
+    TPIKPos = Vector(-8, 6, -4),
+    TPIKAng = Angle(-11, 0, 180),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_pkm.lua
+++ b/lua/weapons/arc9_cod2019_pkm.lua
@@ -36,8 +36,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_lmg_pkm.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-7, 5, 4),
+    TPIKAng = Angle(-9, -1, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_raal.lua
+++ b/lua/weapons/arc9_cod2019_raal.lua
@@ -36,8 +36,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_lmg_raal.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-7, 4, -2),
+    TPIKAng = Angle(-9, -1, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_ram7.lua
+++ b/lua/weapons/arc9_cod2019_ram7.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_rif_ram7.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-6, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-6.5, 5, -2),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_renetti.lua
+++ b/lua/weapons/arc9_cod2019_renetti.lua
@@ -220,7 +220,7 @@ SWEP.CamQCA_Mult = 1
 SWEP.ShellModel = "models/models/weapons/shared/shell_9mm_hr.mdl"
 SWEP.ShellSounds = ARC9.PistolShellSoundsTable
 SWEP.ShellCorrectAng = Angle(0, 0, 0)
-SWEP.ShellScale = 0.08
+SWEP.ShellScale = 0.06
 SWEP.ShellPhysBox = Vector(0.5, 0.5, 2)
 
 SWEP.ShouldDropMag = false

--- a/lua/weapons/arc9_cod2019_rpg.lua
+++ b/lua/weapons/arc9_cod2019_rpg.lua
@@ -29,8 +29,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_eq_rpg.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-11, 6, -2.5),
     Ang = Angle(-17, 3, 180),
-    TPIKPos = Vector(-15, 5, 0),
-    TPIKAng = Angle(0, 0, 180),
+    TPIKPos = Vector(-7, 5, -3),
+    TPIKAng = Angle (-7, 0, 180),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_rpg.lua
+++ b/lua/weapons/arc9_cod2019_rpg.lua
@@ -29,8 +29,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_eq_rpg.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-11, 6, -2.5),
     Ang = Angle(-17, 3, 180),
-    TPIKPos = Vector(-7, 5, -3),
-    TPIKAng = Angle (-7, 0, 180),
+    TPIKPos = Vector(-5, 5, -1),
+    TPIKAng = Angle(-9, 0, 165),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_rytec.lua
+++ b/lua/weapons/arc9_cod2019_rytec.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_snip_rytec.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-6, 6, -1),
+    TPIKAng = Angle(-10, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_sa86.lua
+++ b/lua/weapons/arc9_cod2019_sa86.lua
@@ -36,8 +36,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_lmg_sa86.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-7, 5, -2),
+    TPIKAng = Angle(-9, -1, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_scar.lua
+++ b/lua/weapons/arc9_cod2019_scar.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_rif_scar.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-8.4, 5.5, -2.3),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_strela.lua
+++ b/lua/weapons/arc9_cod2019_strela.lua
@@ -32,8 +32,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_eq_strela.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-9, 8, -4),
     Ang = Angle(-17, 3, 190),
-    TPIKPos = Vector(-4, 6, 0),
-    TPIKAng = Angle(0, 0, 180),
+    TPIKPos = Vector(-4, 7.5, -5),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_striker45.lua
+++ b/lua/weapons/arc9_cod2019_striker45.lua
@@ -7,6 +7,7 @@ SWEP.Category = "ARC9 - MW2019"
 SWEP.SubCategory = "Submachine Guns"
 
 SWEP.PrintName = "Striker 45"
+SWEP.TrueName = "H&K UMP45"
 
 SWEP.Class = "Submachine Gun"
 SWEP.Trivia = {
@@ -37,8 +38,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_smg_striker45.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-8, 5, -1.5),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_svd.lua
+++ b/lua/weapons/arc9_cod2019_svd.lua
@@ -36,8 +36,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_snip_svd.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-6, 4, 0),
+    TPIKAng = Angle(-12, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_sykov.lua
+++ b/lua/weapons/arc9_cod2019_sykov.lua
@@ -219,7 +219,7 @@ SWEP.CamQCA_Mult = 1
 SWEP.ShellModel = "models/models/weapons/shared/shell_9mm_hr.mdl"
 SWEP.ShellSounds = ARC9.PistolShellSoundsTable
 SWEP.ShellCorrectAng = Angle(0, 0, 0)
-SWEP.ShellScale = 0.08
+SWEP.ShellScale = 0.055
 SWEP.ShellPhysBox = Vector(0.5, 0.5, 2)
 
 SWEP.ShouldDropMag = false

--- a/lua/weapons/arc9_cod2019_uzi.lua
+++ b/lua/weapons/arc9_cod2019_uzi.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_smg_uzi.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-6.5, 5, -1.5),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_vector.lua
+++ b/lua/weapons/arc9_cod2019_vector.lua
@@ -227,7 +227,7 @@ SWEP.CamQCA_Mult = 1
 
 SWEP.ShellModel = "models/models/weapons/shared/shell_9mm_hr.mdl"
 SWEP.ShellCorrectAng = Angle(0, 0, 0)
-SWEP.ShellScale = 0.07
+SWEP.ShellScale = 0.06
 SWEP.ShellPhysBox = Vector(0.5, 0.5, 2)
 
 SWEP.ShouldDropMag = false

--- a/lua/weapons/arc9_cod2019_vector.lua
+++ b/lua/weapons/arc9_cod2019_vector.lua
@@ -37,8 +37,8 @@ SWEP.WorldModelMirror = "models/weapons/cod2019/c_smg_vector.mdl"
 SWEP.WorldModelOffset = {
     Pos = Vector(-12, 6, -7.5),
     Ang = Angle(-5, 0, 180),
-    TPIKPos = Vector(-10, 4, 0),
-    TPIKAng = Angle(0, 0, 175),
+    TPIKPos = Vector(-7, 5, -1.5),
+    TPIKAng = Angle(-9, 0, 175),
     Scale = 1
 }
 

--- a/lua/weapons/arc9_cod2019_x16.lua
+++ b/lua/weapons/arc9_cod2019_x16.lua
@@ -219,7 +219,7 @@ SWEP.CamQCA_Mult = 1
 SWEP.ShellModel = "models/models/weapons/shared/shell_9mm_hr.mdl"
 SWEP.ShellSounds = ARC9.PistolShellSoundsTable
 SWEP.ShellCorrectAng = Angle(0, 0, 0)
-SWEP.ShellScale = 0.08
+SWEP.ShellScale = 0.06
 SWEP.ShellPhysBox = Vector(0.5, 0.5, 2)
 
 SWEP.ShouldDropMag = false


### PR DESCRIPTION
I was just going to do the RPG-7 originally since it had bad third person positioning, but I got a little sidetracked. I followed the same baseline for my position adjustments; When facing forward, the gun should be tilted up to a proper angle & should be shouldered at a semi-proper level.

The TPIK adjustments were all done using a stock player model, specifically Male 07 to ensure consistency. I should have used one of the armored models, as those are a bit bigger and thus reflect more PMs on the workshop, but oh well.

Finally, I scaled down a few casing ejections. I would do them all, but I don't have it in me. For most of the scaling, all I did was drop it by 0.01 to fit the ejection port & the magazine, while also keeping the fact that cartridges fire their projectile, and thus would reduce the total profile of the spent casing.