### PR TITLE
Mag drop updates & Other Changes

### DIFF
--- a/lua/weapons/arc9_cod2019_mm_spr208.lua
+++ b/lua/weapons/arc9_cod2019_mm_spr208.lua
@@ -287,7 +287,7 @@ SWEP.DropMagazineSounds = {
 SWEP.DropMagazineAmount = 1 -- Amount of mags to drop.
 SWEP.DropMagazineTime = 1.6
 SWEP.DropMagazineQCA = 3
-SWEP.DropMagazineAng = Angle(0, -90, 0)
+SWEP.DropMagazineAng = Angle(0, -90, -90)
 
 -------------------------- SOUNDS
 
@@ -404,7 +404,7 @@ SWEP.Animations = {
 		RefillProgress = 0.875,
 		PeekProgress = 0.95,
 		FireASAP = true,
-		EjectAt = 0.4,
+		EjectAt = 0.6,
 		DropMagAt = 1.5,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 1 },
@@ -448,7 +448,7 @@ SWEP.Animations = {
 		RefillProgress = 0.85,
 		PeekProgress = 0.925,
 		FireASAP = true,
-		EjectAt = 2,
+		EjectAt = 2.05,
 		DropMagAt = 0.9,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 1 },
@@ -493,8 +493,8 @@ SWEP.Animations = {
 		RefillProgress = 0.875,
 		PeekProgress = 0.95,
 		FireASAP = true,
-		EjectAt = 0.4,
-		DropMagAt = 0.8,
+		EjectAt = 0.6,
+		DropMagAt = 1.5,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 1 },
             { t = 0.1, lhik = 1, rhik = 0 },
@@ -538,8 +538,8 @@ SWEP.Animations = {
 		RefillProgress = 0.85,
 		PeekProgress = 0.925,
 		FireASAP = true,
-		EjectAt = 2,
-		DropMagAt = 0.9,
+		EjectAt = 2.25,
+		DropMagAt = 1,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 1 },
             { t = 0.1, lhik = 0, rhik = 1 },

--- a/lua/weapons/arc9_cod2019_sm_cx9.lua
+++ b/lua/weapons/arc9_cod2019_sm_cx9.lua
@@ -300,7 +300,7 @@ SWEP.DropMagazineSounds = {
 SWEP.DropMagazineAmount = 1 -- Amount of mags to drop.
 SWEP.DropMagazineTime = 0.9
 SWEP.DropMagazineQCA = 3
-SWEP.DropMagazineAng = Angle(0, -90, 0)
+SWEP.DropMagazineAng = Angle(0, -90, -90)
 
 -------------------------- SOUNDS
 
@@ -384,7 +384,7 @@ SWEP.Animations = {
 		PeekProgress = 0.85,
 		RefillProgress = 0.675,
 		FireASAP = true,
-		DropMagAt = 1,
+		DropMagAt = 1.05,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.2, lhik = 0, rhik = 0 },
@@ -495,7 +495,7 @@ SWEP.Animations = {
 		PeekProgress = 0.8,
 		RefillProgress = 0.65,
 		FireASAP = true,
-		DropMagAt = 0.5,
+		DropMagAt = 0.4,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.2, lhik = 0, rhik = 0 },
@@ -516,7 +516,7 @@ SWEP.Animations = {
 		PeekProgress = 0.8,
 		RefillProgress = 0.675,
 		FireASAP = true,
-		DropMagAt = 0.5,
+		DropMagAt = 0.4,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.2, lhik = 0, rhik = 0 },

--- a/lua/weapons/arc9_cod2019_sm_mp5.lua
+++ b/lua/weapons/arc9_cod2019_sm_mp5.lua
@@ -289,7 +289,7 @@ SWEP.DropMagazineSounds = {
 SWEP.DropMagazineAmount = 1 -- Amount of mags to drop.
 SWEP.DropMagazineTime = 0.4
 SWEP.DropMagazineQCA = 3
-SWEP.DropMagazineAng = Angle(0, -90, 0)
+SWEP.DropMagazineAng = Angle(0, -90, -90)
 
 -------------------------- SOUNDS
 
@@ -433,7 +433,7 @@ SWEP.Animations = {
 		PeekProgress = 0.925,
 		RefillProgress = 0.825,
 		FireASAP = true,
-		DropMagAt = 0.8,
+		DropMagAt = 0.7,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 1 },
             { t = 0.1, lhik = 0, rhik = 1 },
@@ -531,7 +531,7 @@ SWEP.Animations = {
 		PeekProgress = 0.925,
 		RefillProgress = 0.825,
 		FireASAP = true,
-		DropMagAt = 0.8,
+		DropMagAt = 0.7,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 1 },
             { t = 0.1, lhik = 0, rhik = 1 },

--- a/lua/weapons/arc9_cod2019_sm_mp7.lua
+++ b/lua/weapons/arc9_cod2019_sm_mp7.lua
@@ -290,7 +290,7 @@ SWEP.DropMagazineSounds = {
 SWEP.DropMagazineAmount = 1 -- Amount of mags to drop.
 SWEP.DropMagazineTime = 0.4
 SWEP.DropMagazineQCA = 3
-SWEP.DropMagazineAng = Angle(0, -90, 0)
+SWEP.DropMagazineAng = Angle(0, -90, -90)
 
 -------------------------- SOUNDS
 
@@ -378,7 +378,7 @@ SWEP.Animations = {
 		PeekProgress = 0.875,
 		RefillProgress = 0.7,
 		FireASAP = true,
-		DropMagAt = 0.65,
+		DropMagAt = 0.6,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.2, lhik = 0, rhik = 0 },
@@ -515,7 +515,7 @@ SWEP.Animations = {
 		PeekProgress = 0.875,
 		RefillProgress = 0.7,
 		FireASAP = true,
-		DropMagAt = 0.7,
+		DropMagAt = 0.65,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.2, lhik = 0, rhik = 0 },
@@ -587,7 +587,7 @@ SWEP.Animations = {
 		RefillProgress = 0.675,
 		FireASAP = true,
 		MagSwapTime = 1.5,
-		DropMagAt = 0.475,
+		DropMagAt = 0.5,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.2, lhik = 0, rhik = 0 },
@@ -609,7 +609,7 @@ SWEP.Animations = {
 		PeekProgress = 0.875,
 		RefillProgress = 0.7,
 		FireASAP = true,
-		DropMagAt = 0.4,
+		DropMagAt = 0.475,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.2, lhik = 0, rhik = 0 },

--- a/lua/weapons/arc9_cod2019_sm_p90.lua
+++ b/lua/weapons/arc9_cod2019_sm_p90.lua
@@ -264,10 +264,10 @@ SWEP.ProceduralViewQCA = 1
 SWEP.CamQCA = 4
 SWEP.CamQCA_Mult = 1
 
-SWEP.ShellModel = "models/weapons/cod2019/shared/shell_9mm_hr.mdl"
+SWEP.ShellModel = "models/weapons/cod2019/shared/shell_762_hr.mdl"
 SWEP.ShellSounds = ARC9.COD2019_308_Table
 SWEP.ShellCorrectAng = Angle(0, 0, 0)
-SWEP.ShellScale = 0.08
+SWEP.ShellScale = 0.04
 SWEP.ShellPhysBox = Vector(0.5, 0.5, 2)
 
 SWEP.ShouldDropMag = false
@@ -284,7 +284,7 @@ SWEP.DropMagazineSounds = {
 SWEP.DropMagazineAmount = 1 -- Amount of mags to drop.
 SWEP.DropMagazineTime = 0.4
 SWEP.DropMagazineQCA = 3
-SWEP.DropMagazineAng = Angle(0, -90, 0)
+SWEP.DropMagazineAng = Angle(0, -90, -90)
 
 -------------------------- SOUNDS
 
@@ -373,7 +373,6 @@ SWEP.Animations = {
 		RefillProgress = 0.7,
 		FireASAP = true,
 		MagSwapTime = 1.5,
-		DropMagAt = 0.8,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 1 },
             { t = 0.1, lhik = 0, rhik = 1 },

--- a/lua/weapons/arc9_cod2019_sm_striker45.lua
+++ b/lua/weapons/arc9_cod2019_sm_striker45.lua
@@ -291,7 +291,7 @@ SWEP.DropMagazineSounds = {
 SWEP.DropMagazineAmount = 1 -- Amount of mags to drop.
 SWEP.DropMagazineTime = 0.4
 SWEP.DropMagazineQCA = 3
-SWEP.DropMagazineAng = Angle(0, -90, 0)
+SWEP.DropMagazineAng = Angle(0, -90, -90)
 
 -------------------------- SOUNDS
 


### PR DESCRIPTION
- Adjusted mag drop angles for SP-R 208, CX9, MP5, MP7, and Striker45.
- Synced mag drop times for SP-R 208, CX9, MP5, and MP7.

Other changes;

SP-R 209:
-Synced shell eject times on empty reloads.
FN P90:
-Changed shell model to use 7.62 and scaled it down to resemble more of a 5.7x28mm casing.
-Removed mag drop for normal reload.