### PR TITLE
More mag drop timing syncs

### DIFF
--- a/lua/weapons/arc9_cod2019_lm_pkm.lua
+++ b/lua/weapons/arc9_cod2019_lm_pkm.lua
@@ -456,7 +456,7 @@ SWEP.Animations = {
 		FireASAP = true,
 		RefillProgress = 0.8,
 		MagSwapTime = 3.5,
-		DropMagAt = 2.85,
+		DropMagAt = 2.8,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.2, lhik = 1, rhik = 0 },

--- a/lua/weapons/arc9_cod2019_pi_357.lua
+++ b/lua/weapons/arc9_cod2019_pi_357.lua
@@ -336,7 +336,7 @@ SWEP.Animations = {
         Source = "reload",
 		MinProgress = 0.85,
 		MagSwapTime = 3.5,
-		DropMagAt = 0.7,
+		DropMagAt = 0.75,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.1, lhik = 0, rhik = 0 },
@@ -505,6 +505,7 @@ SWEP.Animations = {
         Source = "reload_stock",
 		MinProgress = 0.85,
 		MagSwapTime = 3.5,
+		DropMagAt = 0.75,
         IKTimeLine = {
 			{ t = 0, lhik = 1, rhik = 0 },
             { t = 0.1, lhik = 0, rhik = 0 },
@@ -529,6 +530,7 @@ SWEP.Animations = {
         Source = "reload_fast_stock",
 		MinProgress = 0.8,
 		MagSwapTime = 3.5,
+		DropMagAt = 0.44,
         IKTimeLine = {
 			{ t = 0, lhik = 1, rhik = 0 },
             { t = 0.1, lhik = 0, rhik = 0 },

--- a/lua/weapons/arc9_cod2019_pi_renetti.lua
+++ b/lua/weapons/arc9_cod2019_pi_renetti.lua
@@ -752,7 +752,7 @@ SWEP.Animations = {
 		PeekProgress = 0.775,
 		RefillProgress = 0.75,
 		FireASAP = true,
-		DropMagAt = 0.8,
+		DropMagAt = 0.475,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.1, lhik = 0, rhik = 0 },
@@ -774,7 +774,7 @@ SWEP.Animations = {
 		RefillProgress = 0.525,
 		FireASAP = true,
 		MagSwapTime = 1.5,
-		DropMagAt = 0.4,
+		DropMagAt = 0.45,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.1, lhik = 0, rhik = 0 },
@@ -795,7 +795,7 @@ SWEP.Animations = {
 		PeekProgress = 0.775,
 		RefillProgress = 0.7,
 		FireASAP = true,
-		DropMagAt = 0.4,
+		DropMagAt = 0.45,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.1, lhik = 0, rhik = 0 },
@@ -838,7 +838,7 @@ SWEP.Animations = {
 		PeekProgress = 0.775,
 		RefillProgress = 0.75,
 		FireASAP = true,
-		DropMagAt = 0.8,
+		DropMagAt = 0.5,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.1, lhik = 0, rhik = 0 },
@@ -860,7 +860,7 @@ SWEP.Animations = {
 		RefillProgress = 0.525,
 		FireASAP = true,
 		MagSwapTime = 1.5,
-		DropMagAt = 0.4,
+		DropMagAt = 0.45,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.1, lhik = 0, rhik = 0 },
@@ -881,7 +881,7 @@ SWEP.Animations = {
 		PeekProgress = 0.775,
 		RefillProgress = 0.7,
 		FireASAP = true,
-		DropMagAt = 0.4,
+		DropMagAt = 0.45,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.1, lhik = 0, rhik = 0 },

--- a/lua/weapons/arc9_cod2019_pi_sykov.lua
+++ b/lua/weapons/arc9_cod2019_pi_sykov.lua
@@ -816,7 +816,7 @@ SWEP.Animations = {
 		PeekProgress = 0.725,
 		RefillProgress = 0.575,
 		FireASAP = true,
-		DropMagAt = 0.7,
+		DropMagAt = 0.75,
 		MagSwapTime = 4,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
@@ -837,7 +837,7 @@ SWEP.Animations = {
 		PeekProgress = 0.75,
 		RefillProgress = 0.65,
 		FireASAP = true,
-		DropMagAt = 0.7,
+		DropMagAt = 0.75,
 		MagSwapTime = 4,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
@@ -904,7 +904,7 @@ SWEP.Animations = {
 		RefillProgress = 0.575,
 		FireASAP = true,
 		MagSwapTime = 4,
-		DropMagAt = 0.7,
+		DropMagAt = 0.75,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.1, lhik = 0, rhik = 0 },
@@ -925,7 +925,7 @@ SWEP.Animations = {
 		RefillProgress = 0.65,
 		FireASAP = true,
 		MagSwapTime = 4,
-		DropMagAt = 0.7,
+		DropMagAt = 0.75,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.1, lhik = 0, rhik = 0 },
@@ -947,7 +947,6 @@ SWEP.Animations = {
 		RefillProgress = 0.625,
 		FireASAP = true,
 		MagSwapTime = 4,
-		DropMagAt = 0.8,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.1, lhik = 0, rhik = 0 },

--- a/lua/weapons/arc9_cod2019_pi_x16.lua
+++ b/lua/weapons/arc9_cod2019_pi_x16.lua
@@ -732,7 +732,7 @@ SWEP.Animations = {
 		PeekProgress = 0.775,
 		RefillProgress = 0.75,
 		FireASAP = true,
-		DropMagAt = 0.8,
+		DropMagAt = 0.525,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.1, lhik = 0, rhik = 0 },
@@ -756,7 +756,7 @@ SWEP.Animations = {
 		RefillProgress = 0.525,
 		FireASAP = true,
 		MagSwapTime = 1.5,
-		DropMagAt = 0.4,
+		DropMagAt = 0.45,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.1, lhik = 0, rhik = 0 },
@@ -776,7 +776,7 @@ SWEP.Animations = {
 		PeekProgress = 0.775,
 		RefillProgress = 0.65,
 		FireASAP = true,
-		DropMagAt = 0.4,
+		DropMagAt = 0.45,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.1, lhik = 0, rhik = 0 },
@@ -902,7 +902,7 @@ SWEP.Animations = {
 		PeekProgress = 0.775,
 		RefillProgress = 0.75,
 		FireASAP = true,
-		DropMagAt = 0.8,
+		DropMagAt = 0.525,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.1, lhik = 0, rhik = 0 },
@@ -926,7 +926,7 @@ SWEP.Animations = {
 		RefillProgress = 0.525,
 		FireASAP = true,
 		MagSwapTime = 1.5,
-		DropMagAt = 0.5,
+		DropMagAt = 0.475,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.1, lhik = 0, rhik = 0 },


### PR DESCRIPTION
-Resynced mag drop time for PKM's SoH empty reload to keep the model from spawning in the ground.
-Resynced mag drop times for all handguns with stock reloads.
-Added missing shell eject for the .357's stock reloads.