### PR TITLE
Small fixes & Mag Adjustments

### DIFF
--- a/lua/weapons/arc9_cod2019_sh_vlk.lua
+++ b/lua/weapons/arc9_cod2019_sh_vlk.lua
@@ -272,7 +272,7 @@ SWEP.DropMagazineSounds = {
 SWEP.DropMagazineAmount = 1 -- Amount of mags to drop.
 SWEP.DropMagazineTime = 0.85
 SWEP.DropMagazineQCA = 3
-SWEP.DropMagazineAng = Angle(0, -90, 0)
+SWEP.DropMagazineAng = Angle(0, -90, -90)
 
 -------------------------- SOUNDS
 
@@ -365,7 +365,7 @@ SWEP.Animations = {
 		RefillProgress = 0.825,
 		PeekProgress = 0.875,
 		FireASAP = true,
-		EjectAt = 0.1,
+		EjectAt = 0.15,
 		DropMagAt = 0.95,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
@@ -413,6 +413,7 @@ SWEP.Animations = {
 		RefillProgress = 0.825,
 		PeekProgress = 0.925,
 		FireASAP = true,
+		EjectAt = 0.15,
 		DropMagAt = 0.75,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
@@ -451,13 +452,13 @@ SWEP.Animations = {
         },
     },
     ["reload_xmag_empty"] = {
-        Source = "reload_xmag_empty",
+        Source = "reload",
 		MinProgress = 0.95,
 		RefillProgress = 0.825,
 		PeekProgress = 0.875,
 		FireASAP = true,
-		EjectAt = 0.1,
-		DropMagAt = 0.9,
+		EjectAt = 0.15,
+		DropMagAt = 0.95,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },
             { t = 0.2, lhik = 0, rhik = 0 },
@@ -504,6 +505,7 @@ SWEP.Animations = {
 		RefillProgress = 0.825,
 		PeekProgress = 0.925,
 		FireASAP = true,
+		EjectAt = 0.15,
 		DropMagAt = 0.75,
         IKTimeLine = {
             { t = 0, lhik = 1, rhik = 0 },

--- a/lua/weapons/arc9_cod2019_sm_bizon.lua
+++ b/lua/weapons/arc9_cod2019_sm_bizon.lua
@@ -509,7 +509,7 @@ SWEP.Animations = {
         },
     },
     ["reload_xmag_fast_empty"] = {
-        Source = "reload_xmag_fast_empty",
+        Source = "reload_fast_empty",
 		MinProgress = 0.925,
 		PeekProgress = 0.85,
 		RefillProgress = 0.725,


### PR DESCRIPTION
Bizon:
-Fixed incorrect animation used for SoH 84-Round mag empty reload.

VLK Rogue:
-Adjusted magazine drop angle.
-Adjusted shell eject times for empty reloads.
-Added missing shell eject for SoH empty reloads.
-Fixed incorrect animation used for empty extended mag reload.